### PR TITLE
Add .env.example with OpenAI key placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-api-key


### PR DESCRIPTION
## Summary
- provide an example environment file with a placeholder for `OPENAI_API_KEY`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a25a89b083259c6bcf8da2a231c8