### PR TITLE
Add Chatty agent wrapper

### DIFF
--- a/chatty.py
+++ b/chatty.py
@@ -1,0 +1,37 @@
+from dotenv import load_dotenv
+import os
+import openai
+
+load_dotenv()
+
+class Chatty:
+    """Minimal interface for GPT-4o-mini with optional safety."""
+
+    def __init__(self, safe: bool = True):
+        self.safe = safe
+        self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        if safe:
+            self.system_prompt = (
+                "You are Chatty, a helpful assistant following the California policy on frontier AI."
+            )
+        else:
+            self.system_prompt = "You are Chatty, a helpful assistant."
+
+    def chat(self, text: str) -> str:
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": text},
+        ]
+        if self.safe and self._triggers(text):
+            return "I'm sorry, but I can't help with that."
+        response = self.client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=messages,
+        )
+        return response.choices[0].message.content
+
+    def _triggers(self, text: str) -> bool:
+        """Basic content filter for the safe mode."""
+        flagged = ["hack", "bomb", "kill", "malware", "illegal"]
+        lowered = text.lower()
+        return any(t in lowered for t in flagged)

--- a/codex.md
+++ b/codex.md
@@ -22,6 +22,7 @@ Whenever new examples are added or existing code changes, update this file so th
 - **opentelemetry_wrapper.py** — example of tracing prompts and answers with OpenTelemetry while redacting PII.
 - **rationale_tag.py** — attaches a short explanation or rationale tag to each answer.
 - **token_heat_map.py** — toy saliency map showing token importances in a response.
+- **chatty.py** — minimal wrapper offering safe and basic Chatty modes.
 
 ## Updating This Codex
 

--- a/hello_world.py
+++ b/hello_world.py
@@ -1,16 +1,5 @@
-from dotenv import load_dotenv
-import os
-import openai
+from chatty import Chatty
 
-# Load environment variables from a .env file if present
-load_dotenv()
-
-# Create OpenAI client using the API key from the environment
-client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[{"role": "user", "content": "tell me a joke?"}],
-)
-
-print(response.choices[0].message.content)
+if __name__ == "__main__":
+    agent = Chatty(safe=True)
+    print(agent.chat("tell me a joke?"))


### PR DESCRIPTION
## Summary
- implement `chatty.py` as a simple GPT-4o-mini wrapper with optional safety filter
- update `hello_world.py` to use the new `Chatty` interface
- document the new script in `codex.md`

## Testing
- `python3 -m py_compile examples/*.py`
- `python3 -m py_compile chatty.py hello_world.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a557e7ec832591e55a76c997fd30