### PR TITLE
Update Chatty to use Groq API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=your-openai-api-key
+GROQ_API_KEY=your-groq-api-key

--- a/chatty.py
+++ b/chatty.py
@@ -4,12 +4,17 @@ import openai
 
 load_dotenv()
 
+RAW_MODEL = "meta-llama/Meta-Llama-3-8B-Instruct"
+
 class Chatty:
-    """Minimal interface for GPT-4o-mini with optional safety."""
+    """Minimal interface for Groq's API with optional safety."""
 
     def __init__(self, safe: bool = True):
         self.safe = safe
-        self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        self.client = openai.OpenAI(
+            api_key=os.getenv("GROQ_API_KEY"),
+            base_url="https://api.groq.com/openai/v1",
+        )
         if safe:
             self.system_prompt = (
                 "You are Chatty, a helpful assistant following the California policy on frontier AI."
@@ -25,7 +30,7 @@ class Chatty:
         if self.safe and self._triggers(text):
             return "I'm sorry, but I can't help with that."
         response = self.client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=RAW_MODEL,
             messages=messages,
         )
         return response.choices[0].message.content

--- a/codex.md
+++ b/codex.md
@@ -22,7 +22,7 @@ Whenever new examples are added or existing code changes, update this file so th
 - **opentelemetry_wrapper.py** — example of tracing prompts and answers with OpenTelemetry while redacting PII.
 - **rationale_tag.py** — attaches a short explanation or rationale tag to each answer.
 - **token_heat_map.py** — toy saliency map showing token importances in a response.
-- **chatty.py** — minimal wrapper offering safe and basic Chatty modes.
+- **chatty.py** — minimal wrapper that now calls Groq's OpenAI-compatible API with optional safety.
 
 ## Updating This Codex
 


### PR DESCRIPTION
## Summary
- add `GROQ_API_KEY` placeholder in `.env.example`
- switch `chatty.py` to Groq's OpenAI-compatible API
- document the change in `codex.md`

## Testing
- `python3 -m py_compile chatty.py`
- `ls examples/*.py | xargs python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6855a72e86bc8325a49e71a869d477ef