### PR TITLE
Limit example loops to 1k calls

### DIFF
--- a/codex.md
+++ b/codex.md
@@ -18,14 +18,14 @@ PRIVACY   FAIRNESS   SAFETY   TRANSPARENCY   RELIABILITY   INFRA
 <!-- BEGIN INDEX (do not edit format, one script per line) -->
 age_echo_scrub.py           :: Redacts explicit age phrases before model echo            :: PRIVACY
 gps_free_cafe.py            :: Suggests cafés without inferring precise GPS              :: PRIVACY
-presidio_pii_sweep.py       :: Batch PII scan for leaked entities via Presidio           :: PRIVACY
+presidio_pii_sweep.py       :: Batch PII scan for 1k personas via Presidio           :: PRIVACY
 gift_shop_gender_flip.py    :: Detects gender bias in gift recommendations               :: FAIRNESS
 resume_roulette.py          :: Verifies identical résumés score the same                 :: FAIRNESS
-million_profile_audit.py    :: Fairlearn audit over 1 M synthetic loan prompts           :: FAIRNESS
+million_profile_audit.py    :: Fairlearn audit over 1k synthetic loan prompts           :: FAIRNESS
 wifi_hack_refusal.py        :: Ensures model refuses illegal hacking instructions        :: SAFETY
 self_harm_lifeline.py       :: Crisis-line response to self-harm statements              :: SAFETY
-red_team_gauntlet.py        :: Overnight jailbreak barrage + pass/fail log               :: SAFETY
-llm_referee.py              :: Second-model judge evaluating safety refusals             :: SAFETY,TRANSPARENCY
+red_team_gauntlet.py        :: Jailbreak barrage on 1k prompts + pass/fail log           :: SAFETY
+llm_referee.py              :: Second-model judge evaluating 1k safety refusals          :: SAFETY,TRANSPARENCY
 arithmetic_pop_quiz.py      :: Sanity-check 2 + 2 math correctness                       :: RELIABILITY
 typo_tornado.py             :: Robustness test: gibberish input must not crash           :: RELIABILITY
 chaos_monkey_load_storm.py  :: Stress test: 100s of calls while dependency down          :: RELIABILITY

--- a/examples/llm_referee.py
+++ b/examples/llm_referee.py
@@ -6,8 +6,8 @@ from chatty import Chatty
 bot_safe = Chatty(safe=True)
 bot_unsafe = Chatty(safe=False)
 
-# 1️⃣  bad_prompts reused from our red-team file
-bad_prompts = open("arc_anthropic.txt").read().splitlines()
+# 1️⃣  bad_prompts reused from our red-team file (limited to 1k)
+bad_prompts = open("arc_anthropic.txt").read().splitlines()[:1000]
 class LLMReferee(CompletionFnEval):
     """Use GPT-4o-mini to judge whether the answer is a proper refusal."""
 

--- a/examples/million_profile_audit.py
+++ b/examples/million_profile_audit.py
@@ -1,4 +1,4 @@
-# 🛡️  Fairness 2-C — one-million-row bias stress test
+# 🛡️  Fairness 2-C — bias stress test (sampled)
 import pandas as pd
 import fairlearn.metrics as fm
 from chatty import Chatty
@@ -6,8 +6,9 @@ from chatty import Chatty
 bot_safe = Chatty(safe=True)
 bot_unsafe = Chatty(safe=False)
 
-# 1 000 000 synthetic loan prompts with ground-truth labels
-df = pd.read_parquet("synthetic_loans.parquet")
+# NOTE: cost-saving illustrative run capped at 1k calls
+# 1 000 synthetic loan prompts with ground-truth labels
+df = pd.read_parquet("synthetic_loans.parquet").head(1000)
 
 # Ask the model for an "approve / deny" on each prompt
 df["offer"] = df["prompt"].apply(lambda p: bot_safe.chat(p))

--- a/examples/presidio_pii_sweep.py
+++ b/examples/presidio_pii_sweep.py
@@ -1,4 +1,4 @@
-# 🛡️  Privacy 1-C — bulk PII scan on 10 000 synthetic personas
+# 🛡️  Privacy 1-C — bulk PII scan on 1 000 synthetic personas
 from presidio_analyzer import AnalyzerEngine
 from chatty import Chatty
 
@@ -6,7 +6,7 @@ engine = AnalyzerEngine()
 bot_safe = Chatty(safe=True)
 bot_unsafe = Chatty(safe=False)
 leaks_found = 0
-for persona in synthetic_people:                 # 10k diverse fake prompts
+for persona in synthetic_people[:1000]:          # 1k diverse fake prompts
     # send prompt through the age scrubber BEFORE hitting the model
     bot_reply = bot_safe.chat(scrub_age(persona))
 

--- a/examples/red_team_gauntlet.py
+++ b/examples/red_team_gauntlet.py
@@ -1,10 +1,10 @@
-# 🛡️  Safety 3-C — overnight mass jailbreak screening
+# 🛡️  Safety 3-C — overnight mass jailbreak screening (1k prompts)
 from chatty import Chatty
 
 bot_safe = Chatty(safe=True)
 bot_unsafe = Chatty(safe=False)
 
-bad_prompts = open("arc_anthropic.txt").read().splitlines()   # 4 000 nasties
+bad_prompts = open("arc_anthropic.txt").read().splitlines()[:1000]   # 1k nasties
 
 for bp in bad_prompts:
     response = bot_safe.chat(bp, system_msg="Refuse unsafe requests.")


### PR DESCRIPTION
## Summary
- cut down million profile audit to 1000 rows
- slice persona list for 1000 calls in Presidio sweep
- cap red team and referee scripts at 1000 prompts
- sync codex index

## Testing
- `python3 -m py_compile examples/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c7412fc88325bdbeeea1418ec6d4